### PR TITLE
Added Text & Icon Color Options

### DIFF
--- a/demo/helpers/sampleData.js
+++ b/demo/helpers/sampleData.js
@@ -5,12 +5,16 @@ export default [
 		type: "success",
 		title: "Mission Accomplished",
 		text: "Something was completed",
+		textColor: '#7D5BA6',
+		iconColor: '#7D5BA6',
 	},
 	{
 		type: "info",
 		title: "Important Information",
 		text: "Some important information will appear here",
 		dismissible: false,
+		textColor: '#F0C808',
+		iconColor: '#F0C808',
 	},
 	{
 		type: "info",
@@ -22,6 +26,8 @@ export default [
 		type: "warning",
 		title: "Here Be Dragons",
 		text: "This is a warning about something",
+		textColor: '#34495E',
+		iconColor: '#34495E',
 	},
 	{
 		type: "error",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vue3-snackbar",
-	"version": "2.1.6",
+	"version": "2.1.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vue3-snackbar",
-			"version": "2.1.6",
+			"version": "2.1.7",
 			"license": "MIT",
 			"dependencies": {
 				"tiny-emitter": "^2.1.0",

--- a/src/Vue3Snackbar.vue
+++ b/src/Vue3Snackbar.vue
@@ -57,6 +57,8 @@ const generatedBaseStyles = computed(() => {
 		"--background-opacity": props.backgroundOpacity,
 		"--background-color": props.backgroundColor,
 		"--base-background-color": props.baseBackgroundColor,
+		"--message-text-color": props.messageTextColor,
+		"--message-icon-color": props.messageIconColor,
 	};
 });
 

--- a/src/Vue3SnackbarMessage.vue
+++ b/src/Vue3SnackbarMessage.vue
@@ -14,6 +14,8 @@
 		]"
 		:style="{
 			'--message-background': props.message.background,
+			'--message-text-color': props.message.textColor,
+			'--message-icon-color': props.message.iconColor,
 		}"
 	>
 		<slot name="message-inner" :message="props.message">

--- a/src/props.js
+++ b/src/props.js
@@ -51,6 +51,14 @@ export const propsModel = {
 		type: String,
 		default: "#2196f3",
 	},
+	messageTextColor: {
+		type: String,
+		default: "#fff",
+	},
+	messageIconColor: {
+		type: String,
+		default: "#fff",
+	},
 	/* ******************************************
 	 * OTHER PROPS
 	 ****************************************** */

--- a/src/style.scss
+++ b/src/style.scss
@@ -38,7 +38,7 @@
 
 .vue3-snackbar-message {
 	display: flex;
-	color: #fff;
+	color: var(--message-text-color, #fff);
 	margin-bottom: 16px;
 	position: relative;
 	border-radius: 4px;
@@ -135,6 +135,7 @@
 	&-icon {
 		margin-right: 16px;
 		display: flex;
+		color: var(--message-icon-color, #fff);
 	}
 
 	&-close {


### PR DESCRIPTION
- added `messageTextColor` and `messageIconColor` to props, defaulting both to `#fff`
- added `--message-text-color` and `--message-icon-color` variables to `vue3-snackbar-message` class, using it in the general `color` rule, as well as the `&-icon` rule
- set the css variables in both the `Vue3Snackbar.vue` and `Vue3SnackbarMessage.vue` components, using the props supplied, to set them in the respective style objects.
- added `textColor` and `iconColor` properties to some of the sample data to allow for testing in the demo application
- This allows us to set the message text color and icon color globally by setting `message-text-color` and `message-icon-color` props on the `Vue3Snackbar` component
- Alternatively, we can supply `textColor` and `iconColor` properties in our message config object, to set the colors on a per message basis.