### PR TITLE
feat: basic accessibility features

### DIFF
--- a/src/Vue3Snackbar.vue
+++ b/src/Vue3Snackbar.vue
@@ -14,6 +14,7 @@
 					:message-class="props.messageClass"
 					:dense="props.dense"
 					:border-class="borderClass"
+					:generate-aria-label="(type) => type === 'error' ? 'Error' : 'Alert'"
 					@dismiss="remove($event, true)"
 				>
 					<!-- @ts-ignore -->

--- a/src/Vue3SnackbarMessage.vue
+++ b/src/Vue3SnackbarMessage.vue
@@ -17,6 +17,8 @@
 			'--message-text-color': props.message.textColor,
 			'--message-icon-color': props.message.iconColor,
 		}"
+		role="alert"
+		:aria-label="props.generateAriaLabel(props.message.type)"
 	>
 		<slot name="message-inner" :message="props.message">
 			<div class="vue3-snackbar-message-wrapper">
@@ -89,6 +91,10 @@ const props = defineProps({
 		type: Boolean,
 		default: false,
 	},
+	generateAriaLabel: {
+		type: Function,
+		default: () => "Alert",
+	}
 });
 
 let timeout = null,


### PR DESCRIPTION
`vue3-snackbar` is missing some basic accessibility features.
This PR adds a proper aria role to the snackbar and also allows to set a custom aria label depending on the type of the message.