### PR TITLE
Make message params optional in JSDoc

### DIFF
--- a/src/props.js
+++ b/src/props.js
@@ -32,13 +32,13 @@ const HTMLElementShim = typeof window !== "undefined" ? HTMLElement : Object;
 
 /**
  * @typedef { Object } SnackbarMessage
- * @property { "warning"|"error"|"info"|"success"|null } type The classification of the message
- * @property { string? } title An optional title string for the message
+ * @property { "warning"|"error"|"info"|"success"|null } [type] The classification of the message
+ * @property { string } [title] An optional title string for the message
  * @property { string } text The text content of the message
- * @property { number? } duration In ms, the time before the message expires
- * @property { boolean? } dismissible Can the message be dismissed manually?
- * @property { LiveRegionRole? } role The aria-role of the message
- * @property { Renderable? } action Any valid Vue component to render in the action slot
+ * @property { number } [duration] In ms, the time before the message expires
+ * @property { boolean } [dismissible] Can the message be dismissed manually?
+ * @property { LiveRegionRole } [role] The aria-role of the message
+ * @property { Renderable } [action] Any valid Vue component to render in the action slot
  */
 
 /**


### PR DESCRIPTION
Hello, I ran into a small issue with types and found the fix. 

The [JSDoc way of declaring a property as optional](https://jsdoc.app/tags-param#optional-parameters-and-default-values) is to use square brackets around the property name. This allows TS users to not need to require all properties defined  on `SnackbarMessage` when using add() to show a snackbar. I believe that was the original intention with the `?` suffix, but that adds `| null` to the type when generating TS types instead of making the properties optional. 